### PR TITLE
[WIP] Testing

### DIFF
--- a/src/mainboard/erying/tgl/devicetree.cb
+++ b/src/mainboard/erying/tgl/devicetree.cb
@@ -16,7 +16,7 @@ chip soc/intel/tigerlake
 
 	# FSP configuration
 	register "eist_enable" = "1"
-	register "SaGv" = "SaGv_Enabled"
+	register "SaGv" = "SaGv_Disabled"
 	register "enable_c6dram" = "1"
 
 	# IT8613E doesn't support s0ix specification, only S3 is possible.
@@ -180,8 +180,8 @@ chip soc/intel/tigerlake
                                 register "FAN2.mode" = "FAN_SMART_AUTOMATIC" # CPU_FAN header
                                 register "FAN2.smart.tmpin"     = "1"
                                 register "FAN2.smart.tmp_off"   = "40"
-                                register "FAN2.smart.tmp_start" = "50"
-                                register "FAN2.smart.tmp_full"  = "72"
+                                register "FAN2.smart.tmp_start" = "86"
+                                register "FAN2.smart.tmp_full"  = "100"
                                 register "FAN2.smart.tmp_delta" = "2"
                                 register "FAN2.smart.pwm_start" = "26"
                                 register "FAN2.smart.slope"     = "24"

--- a/src/mainboard/erying/tgl/ramstage.c
+++ b/src/mainboard/erying/tgl/ramstage.c
@@ -25,4 +25,12 @@ void mainboard_silicon_init_params(FSP_S_CONFIG *params)
         params->CpuPcieRpMaxPayload[1] = 2;
         params->CpuPcieRpEnableCpm[1] = 1;
         params->CpuPcieRpPeerToPeerMode[1] = 1;
+
+
+        //VR limits
+        params->TdcCurrentLimit[0] = 1800;
+        params->TdcCurrentLimit[1] = 1800;
+
+        params->VrVoltageLimit[0] = 1800;
+        params->VrVoltageLimit[1] = 1800;
 }

--- a/src/mainboard/erying/tgl/romstage_fsp_params.c
+++ b/src/mainboard/erying/tgl/romstage_fsp_params.c
@@ -54,7 +54,8 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	// Testing
 	mupd->FspmConfig.VccInMaxLimit = 2250; //Some boards have ther vcore limited due to this value, issue also present in the Erying AMI BIOS
 
-	
+	//mupd->FspmConfig.CpuBclkOcFrequency = 10064;  //BCLK is set to 98 MHz, this should bring it to 100MHz - This also affects Erying original BIOS
+
 	//mupd->FspmConfig.DynamicMemoryChange = 1; 
 	//mupd->FspmConfig.SaVoltageMode = 1;
 	//mupd->FspmConfig.SaVoltageOverride = 1200;  // Any changes on this and the board does not boot, this might be required in order to reach some XMP profiles/Custom profiles

--- a/src/mainboard/erying/tgl/romstage_fsp_params.c
+++ b/src/mainboard/erying/tgl/romstage_fsp_params.c
@@ -39,18 +39,28 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	mupd->FspmConfig.SaOcSupport = 1;
 
 	/* XMP Configuration - Not functional yet! - Will result in FspNotify error 0x80000007! */
-	// mupd->FspmConfig.SpdProfileSelected = 2;	
+	mupd->FspmConfig.SpdProfileSelected = 1;	
 	mupd->FspmConfig.RefClk = 1; // 100MHz
 	mupd->FspmConfig.VddVoltage = 1350; // 1.35v
-	mupd->FspmConfig.Ratio = 0;
+	mupd->FspmConfig.Ratio = 24;
 	mupd->FspmConfig.RingDownBin = 0;
 	mupd->FspmConfig.GearRatio = 1;
 	mupd->FspmConfig.NModeSupport = 1;
 	
 	// Testing
+	// mupd->FspmConfig.SaGv = 4;
+
+	// mupd->FspmConfig.SaGvFreq[0] = 3200;
+	// mupd->FspmConfig.SaGvGear[0] = 2;
+	// mupd->FspmConfig.SaGvFreq[1] = 3200;
+	// mupd->FspmConfig.SaGvGear[1] = 2;
+	// mupd->FspmConfig.SaGvFreq[2] = 3200;
+	// mupd->FspmConfig.SaGvGear[2] = 2;
+	// mupd->FspmConfig.SaGvFreq[3] = 3200;
+	// mupd->FspmConfig.SaGvGear[3] = 1;
 	mupd->FspmConfig.VccInMaxLimit = 2250; //Some boards have ther vcore limited due to this value, issue also present in the Erying AMI BIOS
 
-	//mupd->FspmConfig.CpuBclkOcFrequency = 10064;  //BCLK is set to 98 MHz, this should bring it to 100MHz - This also affects Erying original BIOS
+	// mupd->FspmConfig.CpuBclkOcFrequency = 9900;  //BCLK is set to 98 MHz, this should bring it to 100MHz - This also affects Erying original BIOS
 
 	//mupd->FspmConfig.DynamicMemoryChange = 1; 
 	//mupd->FspmConfig.SaVoltageMode = 1;

--- a/src/mainboard/erying/tgl/romstage_fsp_params.c
+++ b/src/mainboard/erying/tgl/romstage_fsp_params.c
@@ -9,17 +9,16 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 
 	static const struct mb_cfg mem_type = {
 		.type = MEM_TYPE_DDR4,
-		.ddr4_config = { .dq_pins_interleaved = true },
+		.ddr4_config = { .dq_pins_interleaved = true }, // Can this cause issue with single rank memories? disabling results in no post
 	};
 	static const struct mem_spd spd_info = {
-        	.topo = MEM_TOPO_DIMM_MODULE,
+		.topo = MEM_TOPO_DIMM_MODULE,
 		.smbus = {
 			[0] = { .addr_dimm[0] = 0x50, },
 			[1] = { .addr_dimm[0] = 0x52, },
 		},
 	};
 	const bool half_populated = false;
-        memcfg_init(mupd, &mem_type, &spd_info, half_populated);
 
 	// FSP Configuration
 	mupd->FspmConfig.UserBd = 1;
@@ -51,6 +50,37 @@ void mainboard_memory_init_params(FSPM_UPD *mupd)
 	mupd->FspmConfig.RingDownBin = 0;
 	mupd->FspmConfig.GearRatio = 1;
 	mupd->FspmConfig.NModeSupport = 1;
+	
+	// Testing
+	mupd->FspmConfig.VccInMaxLimit = 2250; //Some boards have ther vcore limited due to this value, issue also present in the Erying AMI BIOS
+
+	
+	//mupd->FspmConfig.DynamicMemoryChange = 1; 
+	//mupd->FspmConfig.SaVoltageMode = 1;
+	//mupd->FspmConfig.SaVoltageOverride = 1200;  // Any changes on this and the board does not boot, this might be required in order to reach some XMP profiles/Custom profiles
+
+	// Be carefull it won't boot with wrong values - Very personal values, how can we get this more versatile?
+
+	// mupd->FspmConfig.SpdProfileSelected = 1; // Setting customized profile, can't post with this option
+
+	//mupd->FspmConfig.Ratio = 23; // This seems to be ignored, I believe it needs the Custom profile
+	
+	//Haven't get to the point of hardcoding timings
+	// mupd->FspmConfig.tCL = 14;
+	// mupd->FspmConfig.tRCDtRP = 14;
+	// mupd->FspmConfig.tRAS = 29;
+	// mupd->FspmConfig.tCWL = 12;
+	// mupd->FspmConfig.tFAW = 14;
+	// mupd->FspmConfig.tREFI = 65535;
+	// mupd->FspmConfig.tRFC = 250;
+	// mupd->FspmConfig.tRRD = 4;
+	// mupd->FspmConfig.tRTP = 8;
+	// mupd->FspmConfig.tWR = 16;
+	// mupd->FspmConfig.tWTR = 4;
+
+
+
+	memcfg_init(mupd, &mem_type, &spd_info, half_populated);
 
 	gpio_configure_pads(gpio_table, ARRAY_SIZE(gpio_table));
 }


### PR DESCRIPTION
@ellyq First of all, thanks for all the hard work. We could get this far if it was not for you. I'm speaking in the name of a small, but very enthusiast folks. 

We've run some test this weekend and your build definitely brought more efficiency to the table. We are seeing something  around 10~15 W on high load (sintetic benchmarks)

Our first goal is to port all fixes for the quirks that this board has on the original firmware. Second, have the ability to set custom memory profiles. We had a look on coreboot-configurator but couldn't wrap our heads on how to get it running. It's throwing this error:
`nvramtool: CMOS option table not found in coreboot table.  Apparently, the coreboot installed on this system was built without selecting CONFIG_USE_OPTION_TABLE.`

We've also built nvramtool from source and it throws the same error.  

As we couldn't get coreboot-configurator going we decided to hardcode some parameters, I left some comments in the code with our attempts. We are assuming there a issue selecting the customXmpProfile, as per your code it seems xmp1 is also not working and some issue with SA/Uncore when we set voltage (offset/voltage)

There were also some reports on USB 3.0 hub (docks) not working - Even on latest build. 

We would like to help more, but don't have much expertise on how to troubleshoot/debug coreboot builds. Let us know what are your thoughts and how can we help you more (maybe a coreboot masterclass :P ?) 

